### PR TITLE
Install MariaDB 10.11 instead of 10.6

### DIFF
--- a/base/build
+++ b/base/build
@@ -57,7 +57,7 @@ apt-get install -yqq --no-install-recommends nodejs
 npm -g install grunt-cli
 
 printTitle 'Installing MariaDB'
-curl -sSL https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --skip-maxscale --mariadb-server-version=mariadb-10.6
+curl -sSL https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --skip-maxscale --mariadb-server-version=mariadb-10.11
 apt-get install -yqq --no-install-recommends mariadb-server
 
 printTitle 'Installing Nginx'


### PR DESCRIPTION
It seems that 10.6 is no more available - check
https://dlm.mariadb.com/repo/mariadb-server/10.6/repo/ubuntu/dists/noble/Release
vs
https://dlm.mariadb.com/repo/mariadb-server/10.11/repo/ubuntu/dists/noble/Release

Even if
https://dlm.mariadb.com/rest/releases/mariadb_server/ reports that 10.6 should be available